### PR TITLE
list_of_zipcodes and return_all_data

### DIFF
--- a/zipcode/__init__.py
+++ b/zipcode/__init__.py
@@ -154,6 +154,22 @@ def isinradius(point, distance):
 			zips_in_radius.append(Zip(row))
 	return zips_in_radius
 
+def list_of_zipcodes():
+	_cur.execute('select * from ZIPS')
+
+	zipcode_list = []
+	all = _cur.fetchall()
+	for i in all:
+		zipcode_list.append(i[0])
+	return zipcode_list
+
+def return_all_data():
+	_cur.execute('select * from ZIPS')
+	all = _cur.fetchall()
+
+	return all
+
+
 
 
 


### PR DESCRIPTION
"Added list_of_zipcodes which returns a list of all valid zipcodes and return_all_data which dumps the database so that the user can manage the data how they wish."

I did this because I am making a scraper using python's requests to make a POST request to a server which returns all stores that carry the product I'm looking for that are near that zipcode. Thus, having a list of all valid zipcodes means I can create a loop that sends a request for each zipcode. I figured this might be a functionality that others would appreciate. 
