### PR TITLE
updated zipcode db file

### DIFF
--- a/zipcode/__init__.py
+++ b/zipcode/__init__.py
@@ -84,9 +84,8 @@ class Zip(object):
 	def to_dict(self):
 		vars_self = vars(self)
 		bad_key_list = [x for x in vars_self.keys() if x[0] == '_']
-		for key in vars_self.keys():
-			if key in bad_key_list:
-				del vars_self[key]
+		for key in bad_key_list:
+			del vars_self[key]
 		return vars_self
 
 def _make_zip_list(list_of_zip_tuples):


### PR DESCRIPTION
Fixes issue [#1](https://github.com/buckmaxwell/zipcode/issues/1).

I updated the `zipcode.db` file to fix the "missing zipcodes" issue. The source I used for the data is:
http://federalgovernmentzipcodes.us/free-zipcode-database-Primary.csv

The current db file has 33411 unique zipcodes, the updated db file has 42522 zipcodes. The updated file has the exact same format, layout, number of columns, column names, etc. as the original file, to try to minimize the possibility of bugs being introduced. I've tested all of the package functions with the updated db file, everything seems to work perfectly.